### PR TITLE
Graphite metrics and cli flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-<<<<<<< HEAD
 .idea
-=======
-# Created by .ignore support plugin (hsz.mobi)
->>>>>>> fe007d79a978e5171ebbbc1740d9ee9d30570fae
+.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ADD . /splunk-http-forwarder
 RUN apk --update add go git\
   && export GOPATH=/.gopath \
   && go get github.com/Financial-Times/coco-splunk-http-forwarder \
+  && go get github.com/cyberdelia/go-metrics-graphite \
+  && go get github.com/rcrowley/go-metrics \
   && cd splunk-http-forwarder \
   && go build \
   && mv splunk-http-forwarder /coco-splunk-http-forwarder \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apk --update add go git\
   && apk del go git \
   && rm -rf $GOPATH /var/cache/apk/*
 
-CMD /coco-splunk-http-forwarder -url=$FORWARD_URL -env=$ENV
+CMD /coco-splunk-http-forwarder -url=$FORWARD_URL -env=$ENV -hostname=$HOSTNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN apk --update add go git\
   && apk del go git \
   && rm -rf $GOPATH /var/cache/apk/*
 
-CMD /coco-splunk-http-forwarder -url=$FORWARD_URL
+CMD /coco-splunk-http-forwarder -url=$FORWARD_URL -env=$ENV

--- a/forwarder.go
+++ b/forwarder.go
@@ -7,23 +7,64 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
+	"time"
+	
+	"github.com/cyberdelia/go-metrics-graphite"
+	"github.com/rcrowley/go-metrics"
+
 )
 
 const workers = 8
+var (
+    client *http.Client
+    fwdUrl string
+    env string
+    dryrun bool
+    graphitePrefix string = "coco.services"
+    graphitePostfix string = "splunk-forwarder"
+    graphiteServer string
+    )
+
 
 func main() {
+    if len(fwdUrl) == 0 { //Check whether -url parameter was provided 
+        log.Printf("-url=http_endpoint parameter must be provided")
+        os.Exit(1) //If not fail visibly as we are unable to send logs to Splunk
+    }
+    
 	log.Println("Splunk forwarder: Started")
 	defer log.Println("Splunk forwarder: Stopped")
+    logChan := make(chan string, 256)
 
-	logChan := make(chan string)
+    hostname, err := os.Hostname() //host name reported by the kernel, used for graphiteNamespace
+    if err != nil {
+        log.Println(err)
+    }
+    graphiteNamespace := strings.Join([]string{graphitePrefix, env, graphitePostfix, hostname}, ".") // Join prefix, env and postfix
+    log.Printf("%v namespace: %v", graphiteServer, graphiteNamespace)
+    if dryrun {
+        log.Printf("Dryrun enabled, not connecting to %v", graphiteServer)
+    } else {
+        addr, err := net.ResolveTCPAddr("tcp", graphiteServer)
+        if err != nil {
+            log.Println(err)
+        }
+        go graphite.Graphite(metrics.DefaultRegistry, 5*time.Second, graphitePrefix, addr)        
+    }
+    go metrics.Log(metrics.DefaultRegistry, 5*time.Second, log.New(os.Stdout, "metrics ", log.Lmicroseconds))
+    
+	go queueLenMetrics(logChan)
 
 	for i := 0; i < workers; i++ {
+		log.Printf("Starting worker %v", i)
 		go func() {
 			for msg := range logChan {
-				postToSplunk(msg)					
+				log.Printf("Event received from logChan")
+				postToSplunk(msg)			
 			}
 		}()
 	}
@@ -38,27 +79,45 @@ func main() {
 				return
 			}
 			log.Fatal(err)
-		}
-		logChan <- str
+		} /*else {
+		    log.Printf("Processed event: %v", str)
+		}*/
+		t := metrics.GetOrRegisterTimer("post.queue.latency", metrics.DefaultRegistry)
+		t.Time(func() {
+		  log.Printf("Posting event to logChan")
+		  logChan <- str
+		})
 	}
+}
+
+func queueLenMetrics(queue chan string) {
+    s := metrics.NewExpDecaySample(1024, 0.015)
+    h := metrics.GetOrRegisterHistogram("post.queue.length", metrics.DefaultRegistry, s)
+    for {
+        time.Sleep(200 * time.Millisecond)
+        h.Update(int64(len(queue)))
+    }
 }
 
 func postToSplunk(s string) {
-	r, err := client.Post(fwdUrl, "application/json", strings.NewReader(s))
-	if err != nil {
-		log.Println(err)
-	} else {
-		defer r.Body.Close()
-		io.Copy(ioutil.Discard, r.Body)
-		if r.StatusCode != 200 {
-			log.Printf("Unexpected status code %v when sending %v to %v", r.StatusCode, s, fwdUrl)
-		}
-	}
-
+    t := metrics.GetOrRegisterTimer("post.time", metrics.DefaultRegistry)
+    t.Time(func() {
+        log.Printf("Posting event to Splunk: %v ", s )
+        r, err := client.Post(fwdUrl, "application/json", strings.NewReader(s))
+        if err != nil {
+            log.Println(err)
+        } else {
+            log.Printf("Processing HTTP response code %v", r.StatusCode)
+            defer r.Body.Close()
+            io.Copy(ioutil.Discard, r.Body)
+            if r.StatusCode != 200 {
+                log.Printf("Unexpected status code %v when sending %v to %v", r.StatusCode, s, fwdUrl)
+            } else {
+                log.Printf("Successfully (%v) sent to endpoint %v", r.StatusCode, fwdUrl)
+            }
+        }
+    })
 }
-
-var client *http.Client
-var fwdUrl string
 
 func init() {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
@@ -67,7 +126,10 @@ func init() {
 		MaxIdleConnsPerHost: workers,
 	}
 	client = &http.Client{Transport: transport}
-
-	flag.StringVar(&fwdUrl, "url", "https://user:pwd@splunk.glb.ft.com/coco-up/fleet", "The url to forward to")
+    
+	flag.StringVar(&fwdUrl, "url", "", "The url to forward to")
+	flag.StringVar(&env, "env", "dummy", "environment_tag value")
+	flag.StringVar(&graphiteServer, "graphiteserver", "graphite.ft.com:2003", "Graphite server host name and port")
+	flag.BoolVar(&dryrun, "dryrun", false, "Dryrun boolean value, default false")
 	flag.Parse()
 }

--- a/forwarder.go
+++ b/forwarder.go
@@ -39,8 +39,8 @@ func main() {
     
 	log.Printf("Splunk forwarder (%v workers): Started\n", workers)
 	defer log.Printf("Splunk forwarder: Stopped\n")
-    //logChan := make(chan string, 256)
-    logChan := make(chan string)
+    logChan := make(chan string, 256)
+    //logChan := make(chan string)
 
     hostname, err := os.Hostname() //host name reported by the kernel, used for graphiteNamespace
     if err != nil {
@@ -80,6 +80,7 @@ func main() {
 
 		if err != nil {
 			if err == io.EOF {
+                time.Sleep(10 * time.Second)
 				close(logChan)
 				return
 			}
@@ -109,6 +110,7 @@ func postToSplunk(s string) {
         log.Printf("Posting event to splunk\n")
         r, err := client.Post(fwdUrl, "application/json", strings.NewReader(s))
         if err != nil {
+            log.Printf("Error posting event to splunk\n")
             log.Println(err)
         } else {
             log.Printf("Processing HTTP response code %v", r.StatusCode)

--- a/forwarder.go
+++ b/forwarder.go
@@ -33,12 +33,12 @@ var (
 
 func main() {
     if len(fwdUrl) == 0 { //Check whether -url parameter was provided 
-        log.Printf("-url=http_endpoint parameter must be provided")
+        log.Printf("-url=http_endpoint parameter must be provided\n")
         os.Exit(1) //If not fail visibly as we are unable to send logs to Splunk
     }
     
-	log.Printf("Splunk forwarder (%v workers): Started", workers)
-	defer log.Println("Splunk forwarder: Stopped")
+	log.Printf("Splunk forwarder (%v workers): Started\n", workers)
+	defer log.Printf("Splunk forwarder: Stopped\n")
     //logChan := make(chan string, 256)
     logChan := make(chan string)
 
@@ -47,9 +47,9 @@ func main() {
         log.Println(err)
     }
     graphiteNamespace := strings.Join([]string{graphitePrefix, env, graphitePostfix, hostname}, ".") // Join prefix, env and postfix
-    log.Printf("%v namespace: %v", graphiteServer, graphiteNamespace)
+    log.Printf("%v namespace: %v\n", graphiteServer, graphiteNamespace)
     if dryrun {
-        log.Printf("Dryrun enabled, not connecting to %v", graphiteServer)
+        log.Printf("Dryrun enabled, not connecting to %v\n", graphiteServer)
     } else {
         addr, err := net.ResolveTCPAddr("tcp", graphiteServer)
         if err != nil {
@@ -66,7 +66,7 @@ func main() {
 		go func() {
 			for msg := range logChan {
                 if dryrun {
-                    log.Printf("Dryrun enabled, not posting to %v", fwdUrl)
+                    log.Printf("Dryrun enabled, not posting to %v\n", fwdUrl)
                 } else {
                     postToSplunk(msg)   
                 }
@@ -88,7 +88,7 @@ func main() {
 		t := metrics.GetOrRegisterTimer("post.queue.latency", metrics.DefaultRegistry)
 		t.Time(func() {
 		  counter++
-		  log.Printf("Delivering event %v to logChan", counter)
+		  log.Printf("Delivering event %v to logChan\n", counter)
 		  logChan <- str
 		})
 	}
@@ -106,7 +106,7 @@ func queueLenMetrics(queue chan string) {
 func postToSplunk(s string) {
     t := metrics.GetOrRegisterTimer("post.time", metrics.DefaultRegistry)
     t.Time(func() {
-        log.Printf("Posting event %v to splunk", counter)
+        log.Printf("Posting event to splunk\n")
         r, err := client.Post(fwdUrl, "application/json", strings.NewReader(s))
         if err != nil {
             log.Println(err)
@@ -115,9 +115,9 @@ func postToSplunk(s string) {
             defer r.Body.Close()
             io.Copy(ioutil.Discard, r.Body)
             if r.StatusCode != 200 {
-                log.Printf("Unexpected status code %v when sending %v to %v", r.StatusCode, s, fwdUrl)
+                log.Printf("Unexpected status code %v when sending %v to %v\n", r.StatusCode, s, fwdUrl)
             } else {
-                log.Printf("Successfully (%v) sent to endpoint %v", r.StatusCode, fwdUrl)
+                log.Printf("Successfully (%v) sent to endpoint %v\n", r.StatusCode, fwdUrl)
             }
         }
     })

--- a/forwarder.go
+++ b/forwarder.go
@@ -39,8 +39,8 @@ func main() {
     
 	log.Printf("Splunk forwarder (%v workers): Started", workers)
 	defer log.Println("Splunk forwarder: Stopped")
-    logChan := make(chan string, 256)
-    //logChan := make(chan string)
+    //logChan := make(chan string, 256)
+    logChan := make(chan string)
 
     hostname, err := os.Hostname() //host name reported by the kernel, used for graphiteNamespace
     if err != nil {

--- a/forwarder.go
+++ b/forwarder.go
@@ -11,74 +11,72 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/rcrowley/go-metrics"
-
 )
 
 var (
-    wg sync.WaitGroup
-    client *http.Client
-    fwdUrl string
-    env string
-    dryrun bool
-    workers int
-    graphitePrefix string = "coco.services"
-    graphitePostfix string = "splunk-forwarder"
-    graphiteServer string
-    chan_buffer int
-		hostname string
-    )
-
+	wg              sync.WaitGroup
+	client          *http.Client
+	fwdURL          string
+	env             string
+	dryrun          bool
+	workers         int
+	graphitePrefix  = "coco.services"
+	graphitePostfix = "splunk-forwarder"
+	graphiteServer  string
+	chanBuffer      int
+	hostname        string
+)
 
 func main() {
-    if len(fwdUrl) == 0 { //Check whether -url parameter was provided
-        log.Printf("-url=http_endpoint parameter must be provided\n")
-        os.Exit(1) //If not fail visibly as we are unable to send logs to Splunk
-    }
+	if len(fwdURL) == 0 { //Check whether -url parameter was provided
+		log.Printf("-url=http_endpoint parameter must be provided\n")
+		os.Exit(1) //If not fail visibly as we are unable to send logs to Splunk
+	}
 
-		log.Printf("Splunk forwarder (workers %v, buffer size %v): Started\n", workers, chan_buffer)
-		defer log.Printf("Splunk forwarder: Stopped\n")
-    logChan := make(chan string, chan_buffer)
+	log.Printf("Splunk forwarder (workers %v, buffer size %v): Started\n", workers, chanBuffer)
+	defer log.Printf("Splunk forwarder: Stopped\n")
+	logChan := make(chan string, chanBuffer)
 
-		if len(hostname) == 0 { //Check whether -hostname parameter was provided. If not attempt to resolve
-    	hname, err := os.Hostname() //host name reported by the kernel, used for graphiteNamespace
-    	if err != nil {
-      	log.Println(err)
-				hostname="unkownhost" //Set host name as unkownhost if hostname resolution fail
-    	} else {
-				hostname = hname
-			}
+	if len(hostname) == 0 { //Check whether -hostname parameter was provided. If not attempt to resolve
+		hname, err := os.Hostname() //host name reported by the kernel, used for graphiteNamespace
+		if err != nil {
+			log.Println(err)
+			hostname = "unkownhost" //Set host name as unkownhost if hostname resolution fail
+		} else {
+			hostname = hname
 		}
+	}
 
-    graphiteNamespace := strings.Join([]string{graphitePrefix, env, graphitePostfix, hostname}, ".") // graphiteNamespace ~ prefix.env.postfix.hostname
-    log.Printf("%v namespace: %v\n", graphiteServer, graphiteNamespace)
-    if dryrun {
-        log.Printf("Dryrun enabled, not connecting to %v\n", graphiteServer)
-    } else {
-        addr, err := net.ResolveTCPAddr("tcp", graphiteServer)
-        if err != nil {
-            log.Println(err)
-        }
-    go graphite.Graphite(metrics.DefaultRegistry, 5*time.Second, graphiteNamespace, addr)
-    }
-    go metrics.Log(metrics.DefaultRegistry, 5*time.Second, log.New(os.Stdout, "metrics ", log.Lmicroseconds))
+	graphiteNamespace := strings.Join([]string{graphitePrefix, env, graphitePostfix, hostname}, ".") // graphiteNamespace ~ prefix.env.postfix.hostname
+	log.Printf("%v namespace: %v\n", graphiteServer, graphiteNamespace)
+	if dryrun {
+		log.Printf("Dryrun enabled, not connecting to %v\n", graphiteServer)
+	} else {
+		addr, err := net.ResolveTCPAddr("tcp", graphiteServer)
+		if err != nil {
+			log.Println(err)
+		}
+		go graphite.Graphite(metrics.DefaultRegistry, 5*time.Second, graphiteNamespace, addr)
+	}
+	go metrics.Log(metrics.DefaultRegistry, 5*time.Second, log.New(os.Stdout, "metrics ", log.Lmicroseconds))
 
-		go queueLenMetrics(logChan)
+	go queueLenMetrics(logChan)
 
-		for i := 0; i < workers; i++ {
-			wg.Add(1)
-			go func() {
-      	defer wg.Done()
-				for msg := range logChan {
-					if dryrun {
-          	log.Printf("Dryrun enabled, not posting to %v\n", fwdUrl)
-					} else {
-						postToSplunk(msg)
-          }
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for msg := range logChan {
+				if dryrun {
+					log.Printf("Dryrun enabled, not posting to %v\n", fwdURL)
+				} else {
+					postToSplunk(msg)
+				}
 			}
 		}()
 	}
@@ -98,34 +96,34 @@ func main() {
 		}
 		t := metrics.GetOrRegisterTimer("post.queue.latency", metrics.DefaultRegistry)
 		t.Time(func() {
-		  logChan <- str
+			logChan <- str
 		})
 	}
 }
 
 func queueLenMetrics(queue chan string) {
-    s := metrics.NewExpDecaySample(1024, 0.015)
-    h := metrics.GetOrRegisterHistogram("post.queue.length", metrics.DefaultRegistry, s)
-    for {
-        time.Sleep(200 * time.Millisecond)
-        h.Update(int64(len(queue)))
-    }
+	s := metrics.NewExpDecaySample(1024, 0.015)
+	h := metrics.GetOrRegisterHistogram("post.queue.length", metrics.DefaultRegistry, s)
+	for {
+		time.Sleep(200 * time.Millisecond)
+		h.Update(int64(len(queue)))
+	}
 }
 
 func postToSplunk(s string) {
-    t := metrics.GetOrRegisterTimer("post.time", metrics.DefaultRegistry)
-    t.Time(func() {
-        r, err := client.Post(fwdUrl, "application/json", strings.NewReader(s))
-        if err != nil {
-            log.Println(err)
-        } else {
-            defer r.Body.Close()
-            io.Copy(ioutil.Discard, r.Body)
-            if r.StatusCode != 200 {
-                log.Printf("Unexpected status code %v when sending %v to %v\n", r.StatusCode, s, fwdUrl)
-            }
-        }
-    })
+	t := metrics.GetOrRegisterTimer("post.time", metrics.DefaultRegistry)
+	t.Time(func() {
+		r, err := client.Post(fwdURL, "application/json", strings.NewReader(s))
+		if err != nil {
+			log.Println(err)
+		} else {
+			defer r.Body.Close()
+			io.Copy(ioutil.Discard, r.Body)
+			if r.StatusCode != 200 {
+				log.Printf("Unexpected status code %v when sending %v to %v\n", r.StatusCode, s, fwdURL)
+			}
+		}
+	})
 }
 
 func init() {
@@ -136,12 +134,12 @@ func init() {
 	}
 	client = &http.Client{Transport: transport}
 
-	flag.StringVar(&fwdUrl, "url", "", "The url to forward to")
+	flag.StringVar(&fwdURL, "url", "", "The url to forward to")
 	flag.StringVar(&env, "env", "dummy", "environment_tag value")
 	flag.StringVar(&graphiteServer, "graphiteserver", "graphite.ft.com:2003", "Graphite server host name and port")
 	flag.BoolVar(&dryrun, "dryrun", false, "Dryrun true disables network connectivity. Use it for testing offline. Default value false")
 	flag.IntVar(&workers, "workers", 8, "Number of concurrent workers")
-	flag.IntVar(&chan_buffer, "buffer", 256, "Channel buffer size")
+	flag.IntVar(&chanBuffer, "buffer", 256, "Channel buffer size")
 	flag.StringVar(&hostname, "hostname", "", "Hostname running the service. If empty Go is trying to resolve the hostname.")
 	flag.Parse()
 }

--- a/forwarder.go
+++ b/forwarder.go
@@ -39,7 +39,8 @@ func main() {
     
 	log.Printf("Splunk forwarder (%v workers): Started", workers)
 	defer log.Println("Splunk forwarder: Stopped")
-    logChan := make(chan string)
+    logChan := make(chan string, 256)
+    //logChan := make(chan string)
 
     hostname, err := os.Hostname() //host name reported by the kernel, used for graphiteNamespace
     if err != nil {
@@ -105,6 +106,7 @@ func queueLenMetrics(queue chan string) {
 func postToSplunk(s string) {
     t := metrics.GetOrRegisterTimer("post.time", metrics.DefaultRegistry)
     t.Time(func() {
+        log.Printf("Posting event %v to splunk", counter)
         r, err := client.Post(fwdUrl, "application/json", strings.NewReader(s))
         if err != nil {
             log.Println(err)

--- a/forwarder.go
+++ b/forwarder.go
@@ -38,7 +38,7 @@ func main() {
     
 	log.Println("Splunk forwarder: Started")
 	defer log.Println("Splunk forwarder: Stopped")
-    logChan := make(chan string, 256)
+    logChan := make(chan string)
 
     hostname, err := os.Hostname() //host name reported by the kernel, used for graphiteNamespace
     if err != nil {

--- a/forwarder.go
+++ b/forwarder.go
@@ -84,7 +84,7 @@ func main() {
 			if err == io.EOF {
 				close(logChan)
 				log.Printf("Waiting buffered channel consumer to finish processing messages\n")
-                wg.Wait()
+				wg.Wait()
 				return
 			}
 			log.Fatal(err)

--- a/forwarder.go
+++ b/forwarder.go
@@ -27,6 +27,7 @@ var (
     graphitePrefix string = "coco.services"
     graphitePostfix string = "splunk-forwarder"
     graphiteServer string
+    counter = 0
     )
 
 
@@ -36,7 +37,7 @@ func main() {
         os.Exit(1) //If not fail visibly as we are unable to send logs to Splunk
     }
     
-	log.Println("Splunk forwarder: Started")
+	log.Printf("Splunk forwarder (%v workers): Started", workers)
 	defer log.Println("Splunk forwarder: Stopped")
     logChan := make(chan string)
 
@@ -60,7 +61,7 @@ func main() {
 	go queueLenMetrics(logChan)
 
 	for i := 0; i < workers; i++ {
-		log.Printf("Starting worker %v", i)
+		//log.Printf("Starting worker %v", i)
 		go func() {
 			for msg := range logChan {
                 if dryrun {
@@ -85,6 +86,8 @@ func main() {
 		} 
 		t := metrics.GetOrRegisterTimer("post.queue.latency", metrics.DefaultRegistry)
 		t.Time(func() {
+		  counter++
+		  log.Printf("Delivering event %v to logChan", counter)
 		  logChan <- str
 		})
 	}


### PR DESCRIPTION
This branch enables metrics to be fed to Graphite from splunk-forwarder process. 
Example graphs available here: http://grafana.ft.com/dashboard/db/coco-xp-delivery-coco-splunk-http-forwarder-stats

Branch also introduces new command line arguments.
-graphiteserver (optional, default: graphite.ft.com:2003) - hostname:port of graphite server
-dryrun (optional, default: false) - dryrun true enables to develop in isolation without interacting with Splunk Forwarder cluster or Graphite
-workers (optional, default: 8) - number of workers sending HTTP requests to Splunk Forwarder cluster
-buffer (optional, default: 256) - queue size for unbuffered channel. Buffer value defines how many objects can be put in channel before it starts blocking.
-hostname (optional, default: none). Enables to set the host name to store metrics under in Graphite
